### PR TITLE
Support Scala v2.12 for Facia/FAPI clients

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,11 @@
 import ReleaseTransformations.*
 
 ThisBuild / scalaVersion := "2.13.11"
-ThisBuild / crossScalaVersions := Seq(scalaVersion.value, "3.3.0")
+ThisBuild / crossScalaVersions := Seq(
+  scalaVersion.value,
+  "3.3.0",
+  "2.12.18" // Motivated by facia/FAPI clients still on Scala 2.12
+)
 ThisBuild / scalacOptions := Seq("-deprecation", "-release","11")
 ThisBuild / licenses := Seq("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0"))
 


### PR DESCRIPTION
I'd like to introduce ETag caching capability to the https://github.com/guardian/facia-scala-client, but several consumers of that library are still using Scala 2.12 - easiest to add support for it to this library for now.

