### PR TITLE
sbt: prefer `publish / skip` to `publishArtifact`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -54,9 +54,7 @@ lazy val `etag-caching-root` = (project in file("."))
     `aws-s3-base`,
     `aws-s3-sdk-v2`
   ).settings(baseSettings).settings(
-    publishArtifact := false,
-    publish := {},
-    publishLocal := {},
+    publish / skip := true,
     releaseCrossBuild := true, // true if you cross-build the project for multiple Scala versions
     releaseProcess := Seq[ReleaseStep](
       checkSnapshotDependencies,


### PR DESCRIPTION
Since sbt v1.0 (!), `publish / skip` has been supported as a way of suppressing publishing-actions (eg, for root projects when all we want to publish are the sub-projects, not the root aggregate project).

It's set like this:

```
publish / skip := true
```

...and it's preferred to `publishArtifact := false`: https://github.com/sbt/sbt/issues/3136#issuecomment-296816910

See also:

* https://github.com/sbt/sbt/issues/3136
* https://github.com/sbt/sbt/pull/3380
* https://www.scala-sbt.org/1.x/docs/Publishing.html#Skip+publishing
