### PR TITLE
Remove workaround for old bug in ScalaDoc gen

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -32,9 +32,7 @@ def awsS3WithSdkVersion(version: Int)=
       libraryDependencies ++= Seq(
         awsSdkForVersion(version),
         "com.adobe.testing" % "s3mock-testcontainers" % "3.1.0" % Test
-      ),
-      Compile / doc / sources := // https://github.com/lampepfl/dotty/issues/15288, see also https://github.com/scanamo/scanamo/pull/1643
-        { if (scalaVersion.value.startsWith("3.")) Nil else (Compile / doc / sources).value }
+      )
     )
 
 val awsSdkForVersion = Map(


### PR DESCRIPTION
https://github.com/guardian/etag-caching/commit/fa16dd6c16faaab1165ab6914aafd1aa6155d699 introduced a workaround for a ScalaDoc bug - but that bug has been fixed as of Scala 3.3.1: https://github.com/lampepfl/dotty/pull/16882/commits/f77069a74c4df65c7f69a6476aeb6b52fa8acb48

We upgraded to Scala 3.3.1 with https://github.com/guardian/etag-caching/pull/12, so we can remove the workaround.
