### PR TITLE
Add stub script for compatibility-labelling PRs

### DIFF
--- a/.github/workflows/tryout-sbt-version-policy.yml
+++ b/.github/workflows/tryout-sbt-version-policy.yml
@@ -1,0 +1,18 @@
+name: Compatibility Report
+on:
+  workflow_dispatch:
+  pull_request:
+
+jobs:
+  add_compatibility_report_to_pr:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Add Compatibility Report
+        run: ./update_pr_with_compatibility_info.sh "$PR_NUMBER"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.number }}

--- a/update_pr_with_compatibility_info.sh
+++ b/update_pr_with_compatibility_info.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+pr_number=$1
+
+required_label="Breaks Binary Compatibility"
+
+current_labels=$(gh pr view $pr_number --json labels --jq '.labels[].name | select(endswith("Compatibility"))')
+
+printf "PR %s Current labels:\n%s\n\n" "$pr_number" "$current_labels"
+
+current_labels_to_remove=$(grep -Fx --invert-match "$required_label" <(echo "$current_labels") | paste -sd ',' -)
+
+echo "current_labels_to_remove = $current_labels_to_remove"
+
+gh pr edit $pr_number --remove-label "$current_labels_to_remove" --add-label "$required_label"
+
+if grep -Fxq "$required_label" <(echo "$current_labels") ; then
+  echo "The '$required_label' label was already present, no need to comment"
+else
+  echo "The '$required_label' label was not already present, PR has changed compatability level"
+  gh pr comment $pr_number --body "Mock info: This PR $required_label when compared against most recent release 3.0.0. Details..."
+fi


### PR DESCRIPTION
This is a stub script that doesn't actually output true compatibility information (that information will be coming with https://github.com/scalacenter/sbt-version-policy/pull/184 & subsequent PRs), it's just a demonstration showing what kind of behaviour would be desirable.

It's aiming to show the part 1 of the workflow described in https://github.com/scalacenter/sbt-version-policy/pull/179:

> **Keep devs aware of the compatibility of the PR they're working on** : When a PR is opened on a library repository, an automated workflow comments-on or labels the PR, making them aware that _"This PR breaks binary/source compatibility"_ - the information here would come from the `sbt-version-policy` plugin, but wouldn't require setting a `versionPolicyIntention` - it just establishes _what_ the level of compatibility the PR entails, so that the developer is aware. The assumption here is that whatever the developer is doing, they need to do it, and should just know the compatibility cost the PR is going to have (and possibly, though not necessarily, once informed they may be able to modify the PR to improve the compatibility).


The script is written to add-and-remove labels as appropriate, if the required compatibility label (eg 'Breaks Binary Compatibility') wasn't already present, we assume this is new information and leave a detailed comment. In general, to reduce noise, we wouldn't necessarily want to add a new comment on every push, better to just tell the user how they can get this information by running locally...
