### PR TITLE
Use predefined sbt `License` object

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ ThisBuild / scalacOptions := Seq("-deprecation", "-release:11")
 
 lazy val baseSettings = Seq(
   organization := "com.gu.etag-caching",
-  licenses := Seq("Apache-2.0" -> url("https://www.apache.org/licenses/LICENSE-2.0")),
+  licenses := Seq(License.Apache2),
   libraryDependencies ++= Seq(
     "org.scalatest" %% "scalatest" % "3.2.17" % Test
   ),


### PR DESCRIPTION
The `License` object was added in sbt [v1.6.2](https://github.com/sbt/sbt/releases/tag/v1.6.2) with PR https://github.com/sbt/librarymanagement/pull/395 .

It's more concise, and gives some consistency for how licenses are expressed.

Specifying a license is [*required*](https://central.sonatype.org/publish/requirements/#license-information) for submitting a project to Maven Central.


