### PR TITLE
Allow preview release process to comment on PRs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   release:
     uses: guardian/gha-scala-library-release-workflow/.github/workflows/reusable-release.yml@main
-    permissions: { contents: write }
+    permissions: { contents: write, pull-requests: write }
     secrets:
       SONATYPE_PASSWORD: ${{ secrets.AUTOMATED_MAVEN_RELEASE_SONATYPE_PASSWORD }}
       PGP_PRIVATE_KEY: ${{ secrets.AUTOMATED_MAVEN_RELEASE_PGP_SECRET }}


### PR DESCRIPTION
https://github.com/guardian/gha-scala-library-release-workflow/pull/19 introduces support for publishing preview releases on PR branches, but note this does use the [`pull-requests: write`](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) permission in order to **comment on the PR**, to announce that the release has been published.

Consequently,  [we need to additionally grant the permission](https://github.com/guardian/gha-scala-library-release-workflow/pull/19/files#r1441589383).


