### PR TITLE
Avoid Caffeine exceptions on missing values

### DIFF
--- a/aws-s3/aws-sdk-v2/src/main/scala/com/gu/etagcaching/aws/sdkv2/s3/S3ObjectFetching.scala
+++ b/aws-s3/aws-sdk-v2/src/main/scala/com/gu/etagcaching/aws/sdkv2/s3/S3ObjectFetching.scala
@@ -3,12 +3,12 @@ package com.gu.etagcaching.aws.sdkv2.s3
 import com.gu.etagcaching.Endo
 import com.gu.etagcaching.aws.s3.ObjectId
 import com.gu.etagcaching.aws.sdkv2.s3.response.Transformer
-import com.gu.etagcaching.fetching.{ETaggedData, Fetching}
+import com.gu.etagcaching.fetching.{ETaggedData, Fetching, Missing, MissingOrETagged}
 import software.amazon.awssdk.core.internal.util.ThrowableUtils
 import software.amazon.awssdk.services.s3.S3AsyncClient
-import software.amazon.awssdk.services.s3.model.{GetObjectRequest, S3Exception}
+import software.amazon.awssdk.services.s3.model.{GetObjectRequest, NoSuchKeyException, S3Exception}
 
-import java.net.HttpURLConnection.HTTP_NOT_MODIFIED
+import java.net.HttpURLConnection.{HTTP_NOT_FOUND, HTTP_NOT_MODIFIED}
 import scala.compat.java8.FutureConverters._
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -20,7 +20,7 @@ case class S3ObjectFetching[Response](s3Client: S3AsyncClient, transformer: Tran
   private def performFetch(
     resourceId: ObjectId,
     reqModifier: Endo[GetObjectRequest.Builder] = identity,
-  )(implicit ec: ExecutionContext): Future[ETaggedData[Response]] = {
+  )(implicit ec: ExecutionContext): Future[MissingOrETagged[Response]] = {
     val requestBuilder = GetObjectRequest.builder().bucket(resourceId.bucket).key(resourceId.key)
     val request = reqModifier(requestBuilder).build()
     s3Client.getObject(request, transformer.asyncResponseTransformer())
@@ -29,11 +29,14 @@ case class S3ObjectFetching[Response](s3Client: S3AsyncClient, transformer: Tran
         wrapWithETag,
         ThrowableUtils.getRootCause // see https://github.com/guardian/ophan/commit/49fa22176
       )
+      .recover {
+        case e: NoSuchKeyException if e.statusCode == HTTP_NOT_FOUND => Missing
+      }
   }
 
-  def fetch(key: ObjectId)(implicit ec: ExecutionContext): Future[ETaggedData[Response]] = performFetch(key)
+  def fetch(key: ObjectId)(implicit ec: ExecutionContext): Future[MissingOrETagged[Response]] = performFetch(key)
 
-  def fetchOnlyIfETagChanged(key: ObjectId, eTag: String)(implicit ec: ExecutionContext): Future[Option[ETaggedData[Response]]] =
+  def fetchOnlyIfETagChanged(key: ObjectId, eTag: String)(implicit ec: ExecutionContext): Future[Option[MissingOrETagged[Response]]] =
     performFetch(key, _.ifNoneMatch(eTag)).map(Some(_)).recover {
       case e: S3Exception if e.statusCode == HTTP_NOT_MODIFIED => None // no fresh download because the ETag matched!
     }

--- a/core/src/main/scala/com/gu/etagcaching/Loading.scala
+++ b/core/src/main/scala/com/gu/etagcaching/Loading.scala
@@ -1,6 +1,6 @@
 package com.gu.etagcaching
 
-import com.gu.etagcaching.fetching.{ETaggedData, Fetching}
+import com.gu.etagcaching.fetching.{ETaggedData, Fetching, MissingOrETagged}
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -17,22 +17,22 @@ import scala.concurrent.{ExecutionContext, Future}
  * @tparam V The 'value' for the key - a parsed representation of whatever was in the resource data.
  */
 trait Loading[K, V] {
-  def fetchAndParse(k: K)(implicit ec: ExecutionContext): Future[ETaggedData[V]]
+  def fetchAndParse(k: K)(implicit ec: ExecutionContext): Future[MissingOrETagged[V]]
 
   /**
    * When we have ''old'' `ETaggedData`, we can send the `ETag` with the Fetch request, and the server will return
    * a blank HTTP 304 `Not Modified` response if the content hasn't changed - which means we DO NOT need to parse
    * any new data, and can just reuse our old data, saving us CPU time and network bandwidth.
    */
-  def fetchThenParseIfNecessary(k: K, oldV: ETaggedData[V])(implicit ec: ExecutionContext): Future[ETaggedData[V]]
+  def fetchThenParseIfNecessary(k: K, oldV: ETaggedData[V])(implicit ec: ExecutionContext): Future[MissingOrETagged[V]]
 }
 
 object Loading {
   def by[K, Response, V](fetching: Fetching[K, Response])(parse: Response => V): Loading[K, V] = new Loading[K, V] {
-    def fetchAndParse(key: K)(implicit ec: ExecutionContext): Future[ETaggedData[V]] =
+    def fetchAndParse(key: K)(implicit ec: ExecutionContext): Future[MissingOrETagged[V]] =
       fetching.fetch(key).map(_.map(parse))
 
-    def fetchThenParseIfNecessary(key: K, oldV: ETaggedData[V])(implicit ec: ExecutionContext): Future[ETaggedData[V]] =
+    def fetchThenParseIfNecessary(key: K, oldV: ETaggedData[V])(implicit ec: ExecutionContext): Future[MissingOrETagged[V]] =
       fetching.fetchOnlyIfETagChanged(key, oldV.eTag).map {
         case None => oldV // we got HTTP 304 'NOT MODIFIED': there's no new data - old data is still valid
         case Some(freshResponse) => freshResponse.map(parse)

--- a/core/src/main/scala/com/gu/etagcaching/fetching/ETaggedData.scala
+++ b/core/src/main/scala/com/gu/etagcaching/fetching/ETaggedData.scala
@@ -1,8 +1,0 @@
-package com.gu.etagcaching.fetching
-
-/**
-  * @param eTag https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag
-  */
-case class ETaggedData[T](eTag: String, result: T) {
-  def map[S](f: T => S): ETaggedData[S] = copy(result = f(result))
-}

--- a/core/src/main/scala/com/gu/etagcaching/fetching/MissingOrETagged.scala
+++ b/core/src/main/scala/com/gu/etagcaching/fetching/MissingOrETagged.scala
@@ -1,0 +1,19 @@
+package com.gu.etagcaching.fetching
+
+sealed trait MissingOrETagged[+T] {
+  def map[S](f: T => S): MissingOrETagged[S]
+  def toOption: Option[T]
+}
+
+case object Missing extends MissingOrETagged[Nothing] {
+  override def map[S](f: Nothing => S): MissingOrETagged[S] = Missing
+  override def toOption: Option[Nothing] = None
+}
+
+/**
+  * @param eTag https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag
+  */
+case class ETaggedData[T](eTag: String, result: T) extends MissingOrETagged[T] {
+  override def map[S](f: T => S): ETaggedData[S] = copy(result = f(result))
+  override def toOption: Option[T] = Some(result)
+}


### PR DESCRIPTION
# Why?

We want to use the `etag-caching` library with Facia Scala Client (see https://github.com/guardian/facia-scala-client/pull/287) so that Ophan can do more frequent querying of the Fronts API while _reducing_ CPU & network consumption.

However, the Facia Scala Client, [in normal use](https://github.com/guardian/facia-scala-client/pull/32), will frequently make requests for Collection JSON entries that _don't_ exist in S3. Code already exists in Facia Scala Client to catch & suppress the exceptions when entires don't exist, but as we now want to now put fetching behind a Caffeine cache (ie with `etag-caching`) we run into the problem that _any_ exception during loading _will_ be logged by Caffeine and in our case this makes **excessive logging noise**.

To solve this problem, we now introduce a way for our `Loading` object to indicate the value for a key is `Missing` (eg we are trying to load an S3 key that does not exist) _without_ having to throw an exception. This is an alternative approach to the hacky solution I worked on in https://github.com/guardian/etag-caching/pull/32 !

## Change to external API of `ETagCache`

#### Before

```scala
def get(key: K): Future[V]
```

#### After

```scala
def get(key: K): Future[Option[V]]
```

The only code using the `etag-caching` library at the moment is Frontend, we have a small PR to update Frontend to cope with the API change:

* https://github.com/guardian/frontend/pull/27303

## Internal changes

The Caffeine cache is now storing values which are the new `MissingOrETagged` type, rather than just `ETaggedData`.

We've introduced the `MissingOrETagged` sealed trait to allow us to represent that a fetch result may be _either_ `Missing` or found, returned with `ETaggedData`.

See also:

* https://github.com/guardian/ophan/pull/5506
* https://github.com/guardian/ophan/issues/5971
* https://github.com/guardian/facia-scala-client/pull/287
