### PR TITLE
Use v2 of `gha-scala-library-release-workflow`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   release:
-    uses: guardian/gha-scala-library-release-workflow/.github/workflows/reusable-release.yml@v1
+    uses: guardian/gha-scala-library-release-workflow/.github/workflows/reusable-release.yml@v2
     permissions: { contents: write, pull-requests: write }
     secrets:
       SONATYPE_TOKEN: ${{ secrets.AUTOMATED_MAVEN_RELEASE_SONATYPE_TOKEN }}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,3 @@
 addSbtPlugin("com.github.sbt" % "sbt-release" % "1.4.0")
 
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.12.2")
-
 addSbtPlugin("ch.epfl.scala" % "sbt-version-policy" % "3.2.1")


### PR DESCRIPTION
`gha-scala-library-release-workflow` [v2.0.0](https://github.com/guardian/gha-scala-library-release-workflow/releases/tag/v2.0.0) uses `sbt`'s new built-in support for publishing to Maven Central.

Additionally, we no longer need to include `sbt-sonatype` in our project, thanks to this PR, included in v2:

* https://github.com/guardian/gha-scala-library-release-workflow/pull/62
