### PR TITLE
Try out linting-fix for our release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   release:
-    uses: guardian/gha-scala-library-release-workflow/.github/workflows/reusable-release.yml@v2
+    uses: guardian/gha-scala-library-release-workflow/.github/workflows/reusable-release.yml@remove-lint-warning-on-sonaDeploymentName
     permissions: { contents: write, pull-requests: write }
     secrets:
       SONATYPE_TOKEN: ${{ secrets.AUTOMATED_MAVEN_RELEASE_SONATYPE_TOKEN }}


### PR DESCRIPTION
* https://github.com/guardian/gha-scala-library-release-workflow/pull/64

