### PR TITLE
Go back to main-line versioned releases of `gha-scala-library-release-workflow`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   release:
-    uses: guardian/gha-scala-library-release-workflow/.github/workflows/reusable-release.yml@fix-release-type-input-on-push-release-commit
+    uses: guardian/gha-scala-library-release-workflow/.github/workflows/reusable-release.yml@v2
     permissions: { contents: write, pull-requests: write }
     secrets:
       SONATYPE_TOKEN: ${{ secrets.AUTOMATED_MAVEN_RELEASE_SONATYPE_TOKEN }}


### PR DESCRIPTION
Now that several bugs have been ironed out (post the refactoring into smaller GitHub Actions that occurred with https://github.com/guardian/gha-scala-library-release-workflow/pull/69), we can safely use v2, which is pointing to [v2.0.3](https://github.com/guardian/gha-scala-library-release-workflow/releases/tag/v2.0.3).
