### PR TITLE
Support logging on updated values

### DIFF
--- a/core/src/test/scala/com/gu/etagcaching/FreshnessPolicyTest.scala
+++ b/core/src/test/scala/com/gu/etagcaching/FreshnessPolicyTest.scala
@@ -2,18 +2,22 @@ package com.gu.etagcaching
 
 import com.github.blemale.scaffeine.{AsyncLoadingCache, Scaffeine}
 import com.gu.etagcaching.FreshnessPolicy.{AlwaysWaitForRefreshedValue, TolerateOldValueWhileRefreshing}
+import com.gu.etagcaching.fetching.{ETaggedData, Fetching, MissingOrETagged}
+import org.scalatest.OptionValues
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.concurrent.TimeLimits.failAfter
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.time.SpanSugar._
 
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+import java.util.concurrent.atomic.AtomicInteger
+import scala.concurrent.{ExecutionContext, Future}
 
-class FreshnessPolicyTest extends AnyFlatSpec with Matchers with ScalaFutures {
+class FreshnessPolicyTest extends AnyFlatSpec with Matchers with ScalaFutures with OptionValues {
 
   case class DemoCache(policy: FreshnessPolicy) {
+    import scala.concurrent.ExecutionContext.Implicits.global
+
     lazy val exampleCache: AsyncLoadingCache[String, Int] = {
       def simulateWork(task: String, key: String, millis: Long): Unit = {
         println(s"$task begin: $key")
@@ -53,5 +57,25 @@ class FreshnessPolicyTest extends AnyFlatSpec with Matchers with ScalaFutures {
     failAfter(5.millis) { // should be instant, because we're _not_ waiting for the ETag-checking fetch
       demo.read() shouldBe 0
     }
+  }
+
+  it should "mean that ETagCache won't make additional requests if a value is cached locally" in {
+    val fetching: Fetching[String, Int] = TestFetching.withIncrementingValues
+
+    val eTagCache = new ETagCache[String, Int](
+      fetching.thenParsing(identity),
+      TolerateOldValueWhileRefreshing,
+      _.maximumSize(1).expireAfterWrite(100.millis)
+    )(ExecutionContext.Implicits.global)
+
+    eTagCache.get("KEY").futureValue.value shouldBe 0
+    eTagCache.get("KEY").futureValue.value shouldBe 0
+    eTagCache.get("KEY").futureValue.value shouldBe 0
+    Thread.sleep(200)
+    eTagCache.get("KEY").futureValue.value shouldBe 1
+    Thread.sleep(30)
+    eTagCache.get("KEY").futureValue.value shouldBe 1
+    Thread.sleep(30)
+    eTagCache.get("KEY").futureValue.value shouldBe 1
   }
 }

--- a/core/src/test/scala/com/gu/etagcaching/LoadingTest.scala
+++ b/core/src/test/scala/com/gu/etagcaching/LoadingTest.scala
@@ -1,0 +1,46 @@
+package com.gu.etagcaching
+
+import com.gu.etagcaching.FreshnessPolicy.TolerateOldValueWhileRefreshing
+import com.gu.etagcaching.Loading.Update
+import com.gu.etagcaching.fetching.Fetching
+import org.scalatest.OptionValues
+import org.scalatest.concurrent.{Eventually, ScalaFutures}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.collection.mutable
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration._
+
+class LoadingTest extends AnyFlatSpec with Matchers with ScalaFutures with OptionValues with Eventually {
+  "onUpdate" should "give callbacks that allow logging updates" in {
+    val updates: mutable.Buffer[Update[String, Int]] = mutable.Buffer.empty
+
+    val fetching: Fetching[String, Int] = TestFetching.withIncrementingValues
+
+    val cache = new ETagCache(
+      fetching.thenParsing(identity).onUpdate { update =>
+        updates.append(update)
+        println(s"Got an update: $update")
+      },
+      TolerateOldValueWhileRefreshing,
+      _.maximumSize(1).refreshAfterWrite(100.millis)
+    )
+
+    val expectedUpdates = Seq(
+      Update("key", None, Some(0)),
+      Update("key", Some(0), Some(1))
+    )
+
+    cache.get("key").futureValue shouldBe Some(0)
+    updates shouldBe expectedUpdates.take(1)
+
+    Thread.sleep(105)
+
+    eventually { cache.get("key").futureValue shouldBe Some(1) }
+    updates.toSeq shouldBe expectedUpdates
+
+    Thread.sleep(105)
+    updates.toSeq shouldBe expectedUpdates // No updates if we're not requesting the key from the cache
+  }
+}

--- a/core/src/test/scala/com/gu/etagcaching/LoadingTest.scala
+++ b/core/src/test/scala/com/gu/etagcaching/LoadingTest.scala
@@ -21,7 +21,6 @@ class LoadingTest extends AnyFlatSpec with Matchers with ScalaFutures with Optio
     val cache = new ETagCache(
       fetching.thenParsing(identity).onUpdate { update =>
         updates.append(update)
-        println(s"Got an update: $update")
       },
       TolerateOldValueWhileRefreshing,
       _.maximumSize(1).refreshAfterWrite(100.millis)

--- a/core/src/test/scala/com/gu/etagcaching/TestFetching.scala
+++ b/core/src/test/scala/com/gu/etagcaching/TestFetching.scala
@@ -1,0 +1,20 @@
+package com.gu.etagcaching
+
+import com.gu.etagcaching.fetching.{ETaggedData, Fetching, MissingOrETagged}
+
+import java.util.concurrent.atomic.AtomicInteger
+import scala.concurrent.{ExecutionContext, Future}
+
+object TestFetching {
+
+  def withIncrementingValues: Fetching[String, Int] = new Fetching[String, Int] {
+    val counter = new AtomicInteger()
+
+    override def fetch(key: String)(implicit ec: ExecutionContext): Future[MissingOrETagged[Int]] = {
+      val count = counter.getAndIncrement()
+      Future.successful(ETaggedData(count.toString, count))
+    }
+    override def fetchOnlyIfETagChanged(key: String, eTag: String)(implicit ec: ExecutionContext): Future[Option[MissingOrETagged[Int]]] =
+      fetch(key)(ec).map(Some(_))
+  }
+}


### PR DESCRIPTION
This PR adds a side-effecting `onUpdate` callback that's useful for logging when values have changed:

```scala
ETagCache(
    S3ObjectFetching.byteArraysWith(s3AsyncClient)
      .thenParsing(Json.parse(_).as[FooBar])
      .onUpdate { update => log.info(s"Key ${update.key} has a changed value: ${update.oldV} → ${update.newV}") }
)
```

It's [used](https://github.com/guardian/login.gutools/blob/b19fad5c8ceb56c012cc6ed28b6a25e04dbac146/app/config/Switches.scala#L20-L22) in this new PR on [`guardian/login.gutools`](https://github.com/guardian/login.gutools):

* https://github.com/guardian/login.gutools/pull/100
