### PR TITLE
software.amazon.awssdk:ssm -> 2.32.27

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -38,7 +38,7 @@ def awsS3WithSdkVersion(version: Int)=
 
 val awsSdkForVersion = Map(
 //  1 -> "com.amazonaws" % "aws-java-sdk-s3" % "1.12.487",
-  2 -> "software.amazon.awssdk" % "s3" % "2.32.19"
+  2 -> "software.amazon.awssdk" % "s3" % "2.32.27"
 )
 
 lazy val `aws-s3-base` =


### PR DESCRIPTION
## What does this change?

Bumps `software.amazon.awssdk:ssm` -> `2.32.27` to bring in `netty-codec-http2:4.1.124.Final`, addressing https://github.com/advisories/GHSA-prj3-ccx8-p6x4

## How to test

The library should compile as expected.