### PR TITLE
Support fetching-then-parsing-with-key

### DIFF
--- a/core/src/main/scala/com/gu/etagcaching/Loading.scala
+++ b/core/src/main/scala/com/gu/etagcaching/Loading.scala
@@ -8,11 +8,14 @@ import scala.concurrent.{ExecutionContext, Future}
 /**
  * `Loading` represents the two sequential steps of getting something useful from a remote resource, specifically:
  *
- *  - Fetching
+ *  - [[Fetching]]
  *  - Parsing
  *
- * Our [[Fetching]] interface requires supporting conditional-fetching based on `ETag`s, which means that
- * we can short-cut the Parsing step if the resource hasn't changed.
+ * The [[Fetching]] interface supports conditional-fetching based on `ETag`s, allowing us to short-cut the Parsing step
+ * if the resource hasn't changed.
+ *
+ * The easiest way to get a [[Loading]] instance is with a [[Fetching]] instance - just call
+ * [[Fetching.thenParsing]] to create a [[Loading]] instance.
  *
  * @tparam K The 'key' or resource identifier type - for instance, a URL or S3 Object Id.
  * @tparam V The 'value' for the key - a parsed representation of whatever was in the resource data.
@@ -34,17 +37,6 @@ trait Loading[K, V] {
 }
 
 object Loading {
-  def by[K, Response, V](fetching: Fetching[K, Response])(parse: Response => V)(implicit parsingEC: ExecutionContext): Loading[K, V] = new Loading[K, V] {
-    def fetchAndParse(key: K): Future[MissingOrETagged[V]] =
-      fetching.fetch(key).map(_.map(parse))
-
-    def fetchThenParseIfNecessary(key: K, oldV: ETaggedData[V]): Future[MissingOrETagged[V]] =
-      fetching.fetchOnlyIfETagChanged(key, oldV.eTag).map {
-        case None => oldV // we got HTTP 304 'NOT MODIFIED': there's no new data - old data is still valid
-        case Some(freshResponse) => freshResponse.map(parse)
-      }
-  }
-
   /**
    * Represents an update event for a given key.
    */

--- a/core/src/main/scala/com/gu/etagcaching/fetching/Fetching.scala
+++ b/core/src/main/scala/com/gu/etagcaching/fetching/Fetching.scala
@@ -37,7 +37,32 @@ trait Fetching[K, Response] {
 
   def mapResponse[Response2](f: Response => Response2)(implicit ec: ExecutionContext): Fetching[K, Response2] = ResponseMapper(this)(f)
 
-  def thenParsing[V](parse: Response => V)(implicit parsingEC: ExecutionContext): Loading[K, V] = Loading.by(this)(parse)
+  /**
+   * Transforms this [[Fetching]] instance into a full [[Loading]] instance by saying how to parse
+   * the fetched response.
+   *
+   * If you happen to need the `key` to parse the response, use [[thenParsingWithKey]].
+   */
+  def thenParsing[V](parse: Response => V)(implicit parsingEC: ExecutionContext): Loading[K, V] = thenParsingWithKey((_, response) => parse(response))
+
+  /**
+   * Transforms this [[Fetching]] instance into a full [[Loading]] instance by saying how to parse
+   * the fetched response - in this particular case, the parsing method is passed the `key`
+   * as well as the fetched response, which can be useful if the response by itself doesn't provide
+   * enough context to immediately determine how to parse it.
+   *
+   * If you don't need the `key` to parse the response, just use [[thenParsing]].
+   */
+  def thenParsingWithKey[V](parse: (K, Response) => V)(implicit parsingEC: ExecutionContext): Loading[K, V] = new Loading[K, V] {
+    def fetchAndParse(key: K): Future[MissingOrETagged[V]] =
+      fetch(key).map(_.map(parse(key, _)))
+
+    def fetchThenParseIfNecessary(key: K, oldV: ETaggedData[V]): Future[MissingOrETagged[V]] =
+      fetchOnlyIfETagChanged(key, oldV.eTag).map {
+        case None => oldV // we got HTTP 304 'NOT MODIFIED': there's no new data - old data is still valid
+        case Some(freshResponse) => freshResponse.map(parse(key, _))
+      }
+  }
 }
 
 object Fetching {


### PR DESCRIPTION
This is motivated by fixing Prout's flakey integration tests:

* https://github.com/guardian/prout/pull/146 - Prout makes extensive use of the GitHub API, and its integration test suite involves creating little test repos as test fixtures. Unfortunately, creation of these fixtures would frequently & unpredictably fail.
* https://github.com/rtyley/play-git-hub/pull/18 - the failures were partly caused by bad caching behaviour in [OkHttp](https://square.github.io/okhttp/), which occasionally was _not_ refreshing the cached responses of [conditional requests](https://docs.github.com/en/rest/using-the-rest-api/best-practices-for-using-the-rest-api?apiVersion=2022-11-28#use-conditional-requests-if-appropriate) to the GitHub API. To fix this, `play-git-hub` has switched to use our own `etag-caching` library instead.

The one blocker for `play-git-hub` using our own `etag-caching` library is that the library currently _only_ provides the _response_ to the parser. Yet GitHub API responses do not contain a discriminator which makes it easy to work out what the correct parser is to use - is the response a `Repo`, a `PullRequest` or what!? Therefore we need `etag-caching` to support parser functions that require knowledge of the _key_, as well as the raw response.

## Changes

* Add a new `fetching.thenParsingWithKey()` syntax to complement the `fetching.thenParsing()` method of instantiating a `Loading` instance - which passes the `key`, as well as the raw `response`, to the parser.
* Drop the `Loading.by(fetching)(parser)` syntax for instantiating a `Loading` instance, in favour of the alternative `fetching.thenParsing(parser)` syntax (which previously delegated to `Loading.by(fetching)(parser)`). We don't need two syntaxes for doing the same thing, and the `fetching.thenParsing(parser)` syntax seems more convenient. I definitely _didn't_ want to have the 2x2 matrix of methods covering _with/without-key_ * _located-on-`Loading`/`Fetching`_.