### PR TITLE
Drop Scala 2.12 support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,8 +4,7 @@ import sbtversionpolicy.withsbtrelease.ReleaseVersion
 ThisBuild / scalaVersion := "2.13.16"
 ThisBuild / crossScalaVersions := Seq(
   scalaVersion.value,
-  "3.3.6",
-  "2.12.20" // Motivated by facia/FAPI clients still on Scala 2.12
+  "3.3.6"
 )
 ThisBuild / scalacOptions := Seq("-deprecation", "-release:11")
 


### PR DESCRIPTION
Consumers no longer need Scala 2.12 support in the `etag-caching` library - the original motivator for Scala 2.12 support, Facia Scala client, dropped Scala 2.12 support in July 2024 with https://github.com/guardian/facia-scala-client/pull/318 .

The Scala Guild dashboard also shows that Scala 2.12 artifacts for `etag-caching` are not used anywhere outside of `etag-caching` itself.

https://metrics.gutools.co.uk/d/deuss7wisetc0f/guardian-scala-libraries-used-in-scala-2-12?orgId=1&from=now-6h&to=now&timezone=browser

Dropping Scala 2.12 support means we can now use Scala 2.13 features, eg [`ExecutionContext.parasitic`](https://www.scala-lang.org/api/2.13.16/scala/concurrent/ExecutionContext$$parasitic$.html), which is [useful](https://github.com/guardian/etag-caching/pull/111#pullrequestreview-3184021114) for this PR:

* https://github.com/guardian/etag-caching/pull/111
