### PR TITLE
Minor: tweak release.yml to be slightly more concise

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,5 @@
 name: Release
-
-on:
-  workflow_dispatch:
+on: workflow_dispatch
 
 jobs:
   release:


### PR DESCRIPTION
Just noticed that we could write `on: workflow_dispatch` on one line, and in fact that's what the docs give as an example, so, why not 😄 


* https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#on
* https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#workflow_dispatch
<img width="994" height="444" alt="image" src="https://github.com/user-attachments/assets/0ab1852b-b71d-48c6-95dd-2268d20f5970" />



