### PR TITLE
Fix flakey `FreshnessPolicyTest`

### DIFF
--- a/core/src/test/scala/com/gu/etagcaching/FreshnessPolicyTest.scala
+++ b/core/src/test/scala/com/gu/etagcaching/FreshnessPolicyTest.scala
@@ -1,8 +1,9 @@
 package com.gu.etagcaching
 
 import com.github.blemale.scaffeine.{AsyncLoadingCache, Scaffeine}
+import com.gu.etagcaching.DemoCache.withPolicy
 import com.gu.etagcaching.FreshnessPolicy.{AlwaysWaitForRefreshedValue, TolerateOldValueWhileRefreshing}
-import com.gu.etagcaching.fetching.{ETaggedData, Fetching, MissingOrETagged}
+import com.gu.etagcaching.fetching.Fetching
 import com.gu.etagcaching.testkit.TestFetching
 import org.scalatest.OptionValues
 import org.scalatest.concurrent.ScalaFutures
@@ -11,52 +12,73 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.time.SpanSugar._
 
-import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.ConcurrentLinkedQueue
 import scala.concurrent.{ExecutionContext, Future}
+import scala.jdk.CollectionConverters._
+import scala.util.control.NonFatal
+
+object DemoCache {
+  def withPolicy(policy: FreshnessPolicy, repeats: Int)(f: DemoCache => Unit): Unit = for (n <- 1 to repeats) {
+    val demoCache = DemoCache(policy)
+    demoCache.log(s"Run $n")
+    try {
+      f(demoCache)
+    } catch {
+      case NonFatal(e) => throw new RuntimeException(demoCache.logs, e)
+    }
+  }
+}
+
+case class DemoCache(policy: FreshnessPolicy) extends ScalaFutures {
+  
+  import scala.concurrent.ExecutionContext.Implicits.global
+
+  private val logStore: ConcurrentLinkedQueue[String] = new ConcurrentLinkedQueue[String]()
+
+  def logs: String = logStore.asScala.mkString("\n")
+
+  def log(mess: String): Unit = logStore.add(mess)
+
+  lazy val exampleCache: AsyncLoadingCache[String, Int] = {
+    def simulateWork(task: String, key: String, millis: Long): Unit = {
+      log(s"$task begin: $key")
+      Thread.sleep(millis)
+      log(s"$task end: $key")
+    }
+
+    Scaffeine().buildAsyncFuture[String, Int](
+      loader = key => Future {
+        simulateWork("load", key, 15)
+        0
+      },
+      reloadLoader = Some { case (key, oldValue) => Future {
+        simulateWork("reload", key, 10)
+        oldValue + 1
+      }
+      }
+    )
+  }
+
+  private val reading = policy.on(exampleCache)
+
+  def read(): Int = reading("sample-key").futureValue
+}
 
 class FreshnessPolicyTest extends AnyFlatSpec with Matchers with ScalaFutures with OptionValues {
 
-  case class DemoCache(policy: FreshnessPolicy) {
-    import scala.concurrent.ExecutionContext.Implicits.global
-
-    lazy val exampleCache: AsyncLoadingCache[String, Int] = {
-      def simulateWork(task: String, key: String, millis: Long): Unit = {
-        println(s"$task begin: $key")
-        Thread.sleep(millis)
-        println(s"$task end: $key")
-      }
-
-      Scaffeine().buildAsyncFuture[String, Int](
-        loader = key => Future {
-          simulateWork("load", key, 50)
-          0
-        },
-        reloadLoader = Some { case (key, oldValue) => Future {
-          simulateWork("reload", key, 10)
-          oldValue + 1
-        }
-        }
-      )
-    }
-
-    private val reading = policy.on(exampleCache)
-
-    def read() = reading("sample-key").futureValue
-
-  }
-
   "AlwaysWaitForRefreshedValue policy" should "always give us the latest, refreshed value, even tho' it takes some time to make the ETag-checking fetch" in {
-    val demo = DemoCache(AlwaysWaitForRefreshedValue)
-    demo.read() shouldBe 0
-    demo.read() shouldBe 1
+    withPolicy(AlwaysWaitForRefreshedValue, repeats = 1000) { demo =>
+      demo.read() shouldBe 0
+      demo.read() shouldBe 1
+    }
   }
 
   "TolerateOldValueWhileRefreshing policy" should "return instantly if there's an available old value" in {
-    val demo = DemoCache(TolerateOldValueWhileRefreshing)
-
-    demo.read() shouldBe 0
-    failAfter(5.millis) { // should be instant, because we're _not_ waiting for the ETag-checking fetch
+    withPolicy(TolerateOldValueWhileRefreshing, repeats = 1000) { demo =>
       demo.read() shouldBe 0
+      failAfter(4.millis) { // should be instant, because we're _not_ waiting for the ETag-checking fetch
+        demo.read() shouldBe 0
+      }
     }
   }
 

--- a/core/src/test/scala/com/gu/etagcaching/FreshnessPolicyTest.scala
+++ b/core/src/test/scala/com/gu/etagcaching/FreshnessPolicyTest.scala
@@ -31,8 +31,6 @@ object DemoCache {
 
 case class DemoCache(policy: FreshnessPolicy) extends ScalaFutures {
   
-  import scala.concurrent.ExecutionContext.Implicits.global
-
   private val logStore: ConcurrentLinkedQueue[String] = new ConcurrentLinkedQueue[String]()
 
   def logs: String = logStore.asScala.mkString("\n")
@@ -47,11 +45,11 @@ case class DemoCache(policy: FreshnessPolicy) extends ScalaFutures {
     }
 
     Scaffeine().buildAsyncFuture[String, Int](
-      loader = key => Future {
+      loader = key => Future.successful {
         simulateWork("load", key, 15)
         0
       },
-      reloadLoader = Some { case (key, oldValue) => Future {
+      reloadLoader = Some { case (key, oldValue) => Future.successful {
         simulateWork("reload", key, 10)
         oldValue + 1
       }


### PR DESCRIPTION
_@JamieB-gu & I paired on investigating this flakey test, initially reported by @Divs-B & @tomrf1 :_

This change fixes a test within `FreshnessPolicyTest` that was [failing](https://github.com/guardian/etag-caching/actions/runs/23050709287/job/66950921428#step:4:119) intermittently due to a data race. This is the test as it was - the assertion on line 51 was failing:

https://github.com/guardian/etag-caching/blob/4c7073ab0d3487cd826ae62c422b451371f94d3e/core/src/test/scala/com/gu/etagcaching/FreshnessPolicyTest.scala#L48-L52

## What does this testcase test?

This test is testing one of the two different 'freshness' policies supported by this library, specifically `AlwaysWaitForRefreshedValue`.

Bear in mind that `etag-caching` maintains an in-memory `Scaffeine` cache, which can load/reload values over the network from an ETag-aware service. Such services will, by design, return an empty [`304 Not Modified`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/304) response if the _current_ ETag of the resource matches the one we send in our request.

Because of this, when we're using `etag-caching`, we might want either of these two different behaviours:

* `AlwaysWaitForRefreshedValue` - _always_ hit the network when asked for a key's value, and wait for the response, because we _always_ want the latest value - we're just using `etag-caching` to avoid having to re-download & re-parse the result if the value hasn't changed, and aren't interested in getting quick (possibly outdated) responses from the in-memory cache. Example: https://github.com/guardian/frontend/pull/26338
* `TolerateOldValueWhileRefreshing` - by contrast, _take advantage_ of the in-memory cache, getting an instant response if the value is still cached in there. The cache can be configured to refresh keys before they expire, if desired. Example: https://github.com/guardian/login.gutools/pull/100

In the test, we are using the `AlwaysWaitForRefreshedValue` policy, and reading from a source that just returns `0` when asked to load a value, and just _increments_ the value if asked to reload it. The first read is 'completed' with `.futureValue` (we **expect** a returned value of `0`), and then the next read occurs, (we **expect** a returned value of `1`, because we've performed a 'reload' of a value we already had available in the cache).

## Reproduction

By repeating the test case 1000 times, we were able to fairly reliably reproduce the failure on our local dev machine.

## What did we see when the test failed?

Surprisingly, the debug showed us that only the first `load` was taking place - there was no subsequent `reload`, or even another `load`. The value returned by the second `read()` was merely the cached result of the _first_ read - which isn't really what we want, when we're using `AlwaysWaitForRefreshedValue`.

## How was this going wrong?

This behaviour - deciding whether or not to initiate a reload - is part of the behaviour of the `Caffeine` caching library. `Caffeine` is written with awareness that cache libraries are often used under high concurrent load, and that if many requests come in near-simultaneously, it is _not_ ideal behaviour to invoke the reload action just as many times - better instead, to just refresh once, and let all the callers share the result. However, if _another_ refresh request has just come in, and we've just finished a previous refresh, we _should_ start a new refresh. This is seen in
[`LocalAsyncLoadingCache.LoadingCacheView.tryOptimisticRefresh()`](https://github.com/ben-manes/caffeine/blob/b0723da5976ebb52069f6b0cccfcf44186c3fdf3/caffeine/src/main/java/com/github/benmanes/caffeine/cache/LocalAsyncLoadingCache.java#L213-L222):

```scala
      var lastRefresh = (CompletableFuture<V>) asyncCache.cache().refreshes().get(keyReference);
      if (lastRefresh != null) {
        if (Async.isReady(lastRefresh) || asyncCache.cache().isPendingEviction(key)) {
          asyncCache.cache().refreshes().remove(keyReference, lastRefresh);
        } else {
          return lastRefresh;
        }
      }
```

...when asked to do a refresh, the code looks to see if there is a _current_ refresh in progress, then checks _that_ refresh to see if it's still running - we only want to share it (`return lastRefresh;`) if it's _not_ completed (`Async.isReady(lastRefresh) == false`).

When the testcase was failing, `Async.isReady(lastRefresh)` was returning `false` - despite the fact that in this test, we only ever ask for a refresh after the last refresh completed (after `.futureValue` returns).

Because `Async.isReady(lastRefresh)` was `false` (ie `lastRefresh` is 'ongoing'), the cache decided to reuse that refresh - we saw execution reach this breakpoint:

<img width="1769" height="904" alt="image" src="https://github.com/user-attachments/assets/5ea8b5e5-97b2-4055-af64-f3d454206f29" />

## Why did `Async.isReady` say the thread _wasn't_ completed, when it was?

There is more than 1 thread involved in this situation:

* The test thread, that the test itself is running in
* The `load` thread: https://github.com/guardian/etag-caching/blob/4c7073ab0d3487cd826ae62c422b451371f94d3e/core/src/test/scala/com/gu/etagcaching/FreshnessPolicyTest.scala#L30-L33

I believe that the strange-looking behaviour we're encountering is probably a consequence of the Java Memory Model, initially defined in [Chapter 17 of the Java Language Specification](https://docs.oracle.com/javase/specs/jls/se7/html/jls-17.html#jls-17.4.5), and then honed in [JSR 133](https://www.cs.umd.edu/~pugh/java/memoryModel/jsr133.pdf), which tries to balance what we intuitively expect regarding event-ordering (_this_ happens-before _this_), with all the many optimisations, re-orderings & caches that CPUs & compilers would like to use in order to make our code go faster.

In calling `Async.isReady` from one thread, asking about the status of another thread, there is no obvious _synchronisation_ between threads in the code that I can see. Without synchronisation, events can can appear to occur out of order - as mentioned in the Java Language Specification:

> To some programmers, this behavior may seem "broken". However, it should be noted that this code is improperly synchronized:
> 
> * there is a write in one thread,
> * a read of the same variable by another thread,
> * and the write and read are not ordered by synchronization.
> 
> This situation is an example of a data race ([§17.4.5](https://docs.oracle.com/javase/specs/jls/se7/html/jls-17.html#jls-17.4.5)). When code contains a data race, counterintuitive results are often possible.

That Caffeine does not synchronise this particular read is probably a reasonable performance choice - and the consequences aren't really that bad, for the use-purposes of Caffeine, in that there's a very narrow window where we get the result of a prior refresh - it doesn't seem that bad.

For the purposes of this test though, it's pretty annoying that we sometime hit that window, and the test fails.

## How to fix this?

A few options:

* The Classic: add a `sleep()` between the two reads. How many flakey tests are more-or-less fixed by a `sleep()`?!?
* Avoid multi-threading altogether: the test isn't trying to validate any multi-threaded behaviour, it's trying to test whether reload or loads occur - so we can change the Future used for `load` from one that's created using `Future.apply()` (which allocates a new thread) to `Future.successful()` (that forces evaluation in the current thread).

The second approach - avoiding multi-threading - is what we've gone for in this case.

## Testing the fix

In order to test the fix, we need to do a bit of refactoring - we want to run the testcase a large number of times, but not produce excessive logging. The first commit in this PR performs that refactoring, and the second commit just switches to `Future.successful()` - we can see that the tests consistently fail on the first commit, but pass with the second.

<img width="1187" height="149" alt="image" src="https://github.com/user-attachments/assets/e3d3076b-f228-495d-81c4-981e92297199" />
