### PR TITLE
Update to latest S3Mock, which uses the updated `testcontainers` for Docker v29+

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -31,8 +31,7 @@ def awsS3WithSdkVersion(version: Int)=
     .settings(baseSettings,
       libraryDependencies ++= Seq(
         awsSdkForVersion(version),
-        "com.adobe.testing" % "s3mock-testcontainers" % "4.11.0" % Test,
-        "org.testcontainers" % "testcontainers" % "2.0.4" % Test // Remove this once s3Mock releases version 5.
+        "com.adobe.testing" % "s3mock-testcontainers" % "4.12.4" % Test
       )
     )
 

--- a/build.sbt
+++ b/build.sbt
@@ -31,8 +31,7 @@ def awsS3WithSdkVersion(version: Int)=
     .settings(baseSettings,
       libraryDependencies ++= Seq(
         awsSdkForVersion(version),
-        "com.adobe.testing" % "s3mock-testcontainers" % "4.12.4" % Test,
-        "org.testcontainers" % "testcontainers" % "2.0.4" % Test // Remove this once s3Mock releases version 5.
+        "com.adobe.testing" % "s3mock-testcontainers" % "4.12.4" % Test
       )
     )
 


### PR DESCRIPTION
We recently merged an update to S3Mock (`com.adobe.testing:s3mock-testcontainers`):

* https://github.com/guardian/etag-caching/pull/150

This means we can undo the temporary fix that _explicitly_ added a newer version of `org.testcontainers:testcontainers` with:

* https://github.com/guardian/etag-caching/pull/136

We no longer need to explicitly require a newer version of `testcontainers`, as the latest release of S3Mock already pulls in a sufficiently new version of `testcontainers`, that works with Docker v29+:

* https://github.com/adobe/S3Mock/issues/2962
* https://github.com/adobe/S3Mock/releases/tag/4.12.4
