### PR TITLE
Update s3 dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -37,7 +37,7 @@ def awsS3WithSdkVersion(version: Int)=
 
 val awsSdkForVersion = Map(
 //  1 -> "com.amazonaws" % "aws-java-sdk-s3" % "1.12.487",
-  2 -> "software.amazon.awssdk" % "s3" % "2.42.27"
+  2 -> "software.amazon.awssdk" % "s3" % "2.44.10"
 )
 
 lazy val `aws-s3-base` =


### PR DESCRIPTION
Updates to the latest version of the AWS S3 sdk.
This will resolve various netty-codec vulnerabilities.