### PR TITLE
Revert PR #158 "chore(deps): AWS dependency updates" - to demonstrate that it didn't affect the version of Netty used

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -37,7 +37,7 @@ def awsS3WithSdkVersion(version: Int)=
 
 val awsSdkForVersion = Map(
 //  1 -> "com.amazonaws" % "aws-java-sdk-s3" % "1.12.487",
-  2 -> "software.amazon.awssdk" % "s3" % "2.44.14"
+  2 -> "software.amazon.awssdk" % "s3" % "2.44.10"
 )
 
 lazy val `aws-s3-base` =


### PR DESCRIPTION
As part of providing evidence for this support ticket:

* https://support.github.com/ticket/personal/0/4486911 (_"Dependabot security vulnerability alert raised 1 week late"_)

...this PR reverts guardian/etag-caching#158 - specifically commit 190da09611c221b53003a14a8c719fa6df14fa87 - to demonstrate that, although the version of `software.amazon.awssdk:s3` changed with that commit from `2.44.10` to `2.44.14`, this did not affect the version of `io.netty:netty-handler` used, which remained at `4.1.133.Final`.

GitHub Support will have access to the rebuilt dependency graph, to confirm that the version of `io.netty:netty-handler` was unchanged - they mention:

> We are not able to view previous canonical snapshots for a repository, only the current one
