### PR TITLE
sbt 2

### DIFF
--- a/aws-s3/aws-sdk-v2/src/test/scala/com/gu/etagcaching/aws/sdkv2/s3/S3ObjectFetchingTest.scala
+++ b/aws-s3/aws-sdk-v2/src/test/scala/com/gu/etagcaching/aws/sdkv2/s3/S3ObjectFetchingTest.scala
@@ -13,10 +13,10 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.{BeforeAndAfterAll, OptionValues}
 import org.testcontainers.DockerClientFactory
+import software.amazon.awssdk.core.async.AsyncRequestBody
 import software.amazon.awssdk.services.s3.S3AsyncClient
 import software.amazon.awssdk.services.s3.model.PutObjectRequest
 
-import java.io.File
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.zip.GZIPInputStream
 import scala.compat.java8.FutureConverters._
@@ -99,11 +99,11 @@ class S3ObjectFetchingTest extends AnyFlatSpec with Matchers with ScalaFutures w
   }
 
   private def uploadFile(demoFile: String)(implicit testS3Objects: TestS3Objects): Unit = {
-    val path = new File(getClass.getClassLoader.getResource("demo-files/" + demoFile).getFile).toPath
+    val bytes = getClass.getClassLoader.getResourceAsStream("demo-files/" + demoFile).readAllBytes()
 
     val s3response = s3Client.putObject(
       PutObjectRequest.builder().bucket(testS3Objects.example.bucket).key(testS3Objects.example.key).build(),
-      path
+      AsyncRequestBody.fromBytes(bytes)
     ).toScala.futureValue
 
     assert(s3response.sdkHttpResponse.isSuccessful)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.12.13
+sbt.version = 2.0.1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
 addSbtPlugin("com.github.sbt" % "sbt-release" % "1.5.0")
 
-addSbtPlugin("ch.epfl.scala" % "sbt-version-policy" % "3.2.1")
+addSbtPlugin("ch.epfl.scala" % "sbt-version-policy" % "3.3.0")


### PR DESCRIPTION
Also requires an update to `sbt-version-policy` to get support for sbt 2.

Paired with @rtyley 


## Missing in this PR

We forgot to get a version of sbt-dependency-graph that could run on sbt 2! 

* https://github.com/guardian/etag-caching/pull/166